### PR TITLE
Add pan/zoom to idea graph canvas

### DIFF
--- a/app/ideas/IdeaGraphCanvas.tsx
+++ b/app/ideas/IdeaGraphCanvas.tsx
@@ -81,9 +81,13 @@ export default function IdeaGraphCanvas({
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 })
   const [hasDragged, setHasDragged] = useState(false)
   const [connectionMode, setConnectionMode] = useState<string | null>(null)
+  const [isPanning, setIsPanning] = useState(false)
+  const [panStart, setPanStart] = useState<{ x: number; y: number } | null>(null)
+  const [view, setView] = useState({ x: 0, y: 0, scale: 1 })
 
   // Refs
   const containerRef = useRef<HTMLDivElement>(null)
+  const worldRef = useRef<HTMLDivElement>(null)
   const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map())
   const pendingUpdates = useRef<Map<string, { x: number; y: number }>>(new Map())
   const batchTimer = useRef<NodeJS.Timeout | null>(null)
@@ -190,11 +194,11 @@ export default function IdeaGraphCanvas({
       }
 
       return {
-        x: pos.x + rect.width / 2,
-        y: pos.y + rect.height / 2,
+        x: pos.x + rect.width / (2 * view.scale),
+        y: pos.y + rect.height / (2 * view.scale),
       }
     },
-    [ideaToItemMap, getPosition]
+    [ideaToItemMap, getPosition, view.scale]
   )
 
   // Handle context menu (right click) to start connection
@@ -258,14 +262,14 @@ export default function IdeaGraphCanvas({
       setDragStartPos({ x: e.clientX, y: e.clientY })
 
       const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-      const offsetX = e.clientX - rect.left
-      const offsetY = e.clientY - rect.top
+      const offsetX = (e.clientX - rect.left) / view.scale
+      const offsetY = (e.clientY - rect.top) / view.scale
 
       setDragOffset({ x: offsetX, y: offsetY })
       setDraggingNodeId(itemId)
       setHasDragged(false)
     },
-    [connectionMode]
+    [connectionMode, view.scale]
   )
 
   // Handle click on connection line to delete
@@ -311,8 +315,8 @@ export default function IdeaGraphCanvas({
       requestAnimationFrame(() => {
         if (!containerRef.current) return
         const containerRect = containerRef.current.getBoundingClientRect()
-        const newX = e.clientX - containerRect.left - dragOffset.x
-        const newY = e.clientY - containerRect.top - dragOffset.y
+        const newX = (e.clientX - containerRect.left - view.x) / view.scale - dragOffset.x
+        const newY = (e.clientY - containerRect.top - view.y) / view.scale - dragOffset.y
 
         // Actualizar posición INMEDIATAMENTE en la UI
         setPositions((prev) => {
@@ -322,7 +326,7 @@ export default function IdeaGraphCanvas({
         })
       })
     },
-    [draggingNodeId, dragOffset, dragStartPos]
+    [draggingNodeId, dragOffset, dragStartPos, view.scale, view.x, view.y]
   )
 
   // ⚡ CRÍTICO: Mouse up - trigger debounced save
@@ -383,6 +387,39 @@ export default function IdeaGraphCanvas({
   }, [connectionMode])
 
   useEffect(() => {
+    if (!isPanning) return
+
+    const handleMove = (e: MouseEvent) => {
+      if (!panStart) return
+      const deltaX = e.clientX - panStart.x
+      const deltaY = e.clientY - panStart.y
+      setView((prev) => ({
+        ...prev,
+        x: prev.x + deltaX,
+        y: prev.y + deltaY,
+      }))
+      setPanStart({ x: e.clientX, y: e.clientY })
+    }
+
+    const handleUp = () => {
+      setIsPanning(false)
+      setPanStart(null)
+    }
+
+    window.addEventListener('mousemove', handleMove)
+    window.addEventListener('mouseup', handleUp)
+    document.body.style.cursor = 'grabbing'
+    document.body.style.userSelect = 'none'
+
+    return () => {
+      window.removeEventListener('mousemove', handleMove)
+      window.removeEventListener('mouseup', handleUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+  }, [isPanning, panStart])
+
+  useEffect(() => {
     const timer = batchTimer.current
     const updates = pendingUpdates.current
 
@@ -405,10 +442,35 @@ export default function IdeaGraphCanvas({
 
   return (
     <div
-      className="flex-1 overflow-auto bg-slate-50"
+      className="flex-1 overflow-hidden bg-slate-50"
       ref={containerRef}
+      onMouseDown={(e) => {
+        if (e.button !== 0) return
+        if (draggingNodeId || connectionMode) return
+        const target = e.target as HTMLElement
+        if (target.closest('[data-idea-card="true"]')) return
+        setIsPanning(true)
+        setPanStart({ x: e.clientX, y: e.clientY })
+      }}
+      onWheel={(e) => {
+        if (!containerRef.current) return
+        e.preventDefault()
+        const rect = containerRef.current.getBoundingClientRect()
+        const cursorX = e.clientX - rect.left
+        const cursorY = e.clientY - rect.top
+        const zoomIntensity = 0.0015
+        const nextScale = Math.min(2.5, Math.max(0.4, view.scale * (1 - e.deltaY * zoomIntensity)))
+        const worldX = (cursorX - view.x) / view.scale
+        const worldY = (cursorY - view.y) / view.scale
+        const nextX = cursorX - worldX * nextScale
+        const nextY = cursorY - worldY * nextScale
+        setView({ x: nextX, y: nextY, scale: nextScale })
+      }}
       onClick={(e) => {
-        if (connectionMode && e.target === containerRef.current) {
+        if (
+          connectionMode &&
+          (e.target === containerRef.current || e.target === worldRef.current)
+        ) {
           setConnectionMode(null)
         }
       }}
@@ -431,12 +493,15 @@ export default function IdeaGraphCanvas({
       )}
 
       <div
+        ref={worldRef}
         className="relative"
         style={{
           width: WORLD_WIDTH,
           height: WORLD_HEIGHT,
           minWidth: WORLD_WIDTH,
           minHeight: WORLD_HEIGHT,
+          transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
+          transformOrigin: '0 0',
         }}
       >
         {/* SVG for connections */}
@@ -508,6 +573,7 @@ export default function IdeaGraphCanvas({
                       cardRefs.current.set(item.id, el)
                     }
                   }}
+                  data-idea-card="true"
                   className={`group block ${isDragging
                     ? 'cursor-grabbing'
                     : connectionMode


### PR DESCRIPTION
### Motivation

- Enable manipulating the canvas view (pan and zoom) so users can move around and zoom the idea graph in addition to dragging nodes and connections.

### Description

- Add view state (`view`, `isPanning`, `panStart`) and a `worldRef` to manage panning and zooming and apply `transform: translate(...) scale(...)` to the world container in `app/ideas/IdeaGraphCanvas.tsx`.
- Add background mouse handlers (`onMouseDown` for pan start and `onWheel` for cursor-centered zoom) and a panning `useEffect` that tracks mousemove/up to update the view.
- Adjust node dragging math and `getCardCenter` to account for `view.scale` and `view.x/view.y` so node movement and connection lines remain correct while zoomed/panned, and compute drag offsets in world coordinates.
- Prevent panning when interacting with idea cards by adding a `data-idea-card=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977643e4bc483318c06f0e759ccb3fe)