### PR TITLE
Refactor acciones servidor: usar RPCs atómicos y arreglar N+1 en Todo

### DIFF
--- a/app/budgets/actions.ts
+++ b/app/budgets/actions.ts
@@ -7,12 +7,6 @@ import { revalidatePath } from 'next/cache';
 import { Database } from '@/lib/supabase/types';
 
 type Budget = Database['public']['Tables']['budgets']['Row'];
-type BudgetCategory = Database['public']['Tables']['budget_categories']['Row'];
-type BudgetItem = Database['public']['Tables']['budget_items']['Row'];
-
-type CategoryWithItems = BudgetCategory & {
-  budget_items: BudgetItem[];
-};
 
 // ============================================
 // GET ALL BUDGETS
@@ -181,7 +175,7 @@ export async function createBudget(formData: {
       description: formData.description || null,
       project_id: formData.project_id || null,
       owner_id: user.id,
-    } as any)
+    } as never)
     .select()
     .single();
 
@@ -208,18 +202,19 @@ export async function updateBudget(
   await requireAuth();
   const supabase = await createClient();
 
-  const updates: any = {};
+  const updates: Database['public']['Tables']['budgets']['Update'] = {};
   if (formData.name !== undefined) updates.name = formData.name;
   if (formData.description !== undefined)
     updates.description = formData.description || null;
   if (formData.project_id !== undefined)
     updates.project_id = formData.project_id || null;
 
-  const query: any = (supabase.from('budgets') as any).update(updates as any);
-
-  const result: any = await query.eq('id', budgetId).select().single();
-
-  const { data, error } = result;
+  const { data, error } = await supabase
+    .from('budgets')
+    .update(updates as never)
+    .eq('id', budgetId)
+    .select()
+    .single();
 
   if (error) {
     console.error('Error updating budget:', error);
@@ -256,113 +251,22 @@ export async function duplicateBudget(sourceBudgetId: string) {
   await requireAuth();
   const supabase = await createClient();
 
-  // Fetch source budget
-  const { data: sourceBudget, error: sourceBudgetError } = await supabase
-    .from('budgets')
-    .select(
-      'id, project_id, name, description, owner_id, created_at, updated_at'
-    )
-    .eq('id', sourceBudgetId)
-    .single();
+  const { data: newBudgetId, error } = await supabase.rpc(
+    'duplicate_budget_atomic' as never,
+    {
+      source_id: sourceBudgetId,
+      new_name: '',
+    } as never
+  );
 
-  if (sourceBudgetError || !sourceBudget) {
-    console.error('Error fetching source budget:', sourceBudgetError);
-    throw new Error('Budget not found');
-  }
-
-  const sourceBudgetData = sourceBudget as Budget;
-
-  // Create new budget
-  const { data: newBudget, error: createBudgetError } = await supabase
-    .from('budgets')
-    .insert({
-      name: `${sourceBudgetData.name} (Copy)`,
-      description: sourceBudgetData.description ?? null,
-      project_id: sourceBudgetData.project_id ?? null,
-    } as any)
-    .select()
-    .single();
-
-  if (createBudgetError || !newBudget) {
-    console.error('Error creating duplicated budget:', createBudgetError);
+  if (error || !newBudgetId) {
+    console.error('Error duplicating budget atomically:', error);
     throw new Error('Failed to duplicate budget');
   }
 
-  const newBudgetData = newBudget as Budget;
-
-  // Fetch categories with items
-  const { data: categories, error: categoriesError } = await supabase
-    .from('budget_categories')
-    .select(
-      `
-      *,
-      budget_items (*)
-    `
-    )
-    .eq('budget_id', sourceBudgetId)
-    .order('sort_order', { ascending: true });
-
-  if (categoriesError) {
-    console.error(
-      'Error fetching categories for duplication:',
-      categoriesError
-    );
-    // Budget duplicated, but no categories copied; still return new budget id.
-    revalidatePath('/budgets');
-    revalidatePath(`/budgets/${newBudgetData.id}`);
-    return { budgetId: newBudgetData.id };
-  }
-
-  const categoriesData = (categories || []) as CategoryWithItems[];
-
-  // Copy categories + items (sequential to keep mapping reliable)
-  for (const category of categoriesData) {
-    const { data: newCategory, error: newCategoryError } = await supabase
-      .from('budget_categories')
-      .insert({
-        budget_id: newBudgetData.id,
-        name: category.name,
-        description: category.description ?? null,
-        sort_order: category.sort_order ?? 0,
-      } as any)
-      .select()
-      .single();
-
-    if (newCategoryError || !newCategory) {
-      console.error('Error duplicating category:', newCategoryError);
-      throw new Error('Failed to duplicate budget');
-    }
-
-    const newCategoryId = (newCategory as BudgetCategory).id;
-    const items = (category.budget_items || []) as BudgetItem[];
-
-    if (items.length > 0) {
-      const itemInserts = items.map((item) => ({
-        category_id: newCategoryId,
-        name: item.name,
-        description: item.description ?? null,
-        quantity: item.quantity ?? 1,
-        unit_price: item.unit_price ?? 0,
-        link: item.link ?? null,
-        status: (item.status as any) ?? 'pending',
-        is_recurrent: item.is_recurrent ?? false,
-        notes: item.notes ?? null,
-      }));
-
-      const { error: itemsError } = await supabase
-        .from('budget_items')
-        .insert(itemInserts as any);
-
-      if (itemsError) {
-        console.error('Error duplicating items:', itemsError);
-        throw new Error('Failed to duplicate budget');
-      }
-    }
-  }
-
   revalidatePath('/budgets');
-  revalidatePath(`/budgets/${newBudgetData.id}`);
-  return { budgetId: newBudgetData.id };
+  revalidatePath(`/budgets/${newBudgetId}`);
+  return { budgetId: newBudgetId };
 }
 
 // ============================================

--- a/app/todo/actions.ts
+++ b/app/todo/actions.ts
@@ -332,12 +332,26 @@ export async function getProjectsWithTodoSummaryAction(): Promise<{
         {} as Record<string, string[]>
       );
 
+    const allListIds = lists.map((list) => list.id);
+    const allItems =
+      allListIds.length > 0 ? await getTodoItemsByListIds(allListIds) : [];
+    const itemsByListId = allItems.reduce(
+      (acc, item) => {
+        if (!acc[item.list_id]) {
+          acc[item.list_id] = [];
+        }
+        acc[item.list_id].push(item);
+        return acc;
+      },
+      {} as Record<string, TodoItem[]>
+    );
+
     const summaries: ProjectTodoSummary[] = [];
     for (const project of projects) {
       const listIds = projectListIds[project.id] || [];
       if (listIds.length === 0) continue;
 
-      const items = await getTodoItemsByListIds(listIds);
+      const items = listIds.flatMap((listId) => itemsByListId[listId] || []);
       const pending = items.filter((i) => !i.is_done);
       const previewItems = items.slice(0, 3);
 

--- a/supabase/migrations/20260216_fix_security_and_performance.sql
+++ b/supabase/migrations/20260216_fix_security_and_performance.sql
@@ -1,0 +1,234 @@
+-- ============================================
+-- Fix security and performance audit findings
+-- ============================================
+
+-- ---------------------------------------------------------------------------
+-- SEC-001/002/003: Add WITH CHECK to UPDATE policies
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Users can update categories in own budgets" ON public.budget_categories;
+CREATE POLICY "Users can update categories in own budgets"
+  ON public.budget_categories FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.budgets b
+      WHERE b.id = budget_categories.budget_id
+        AND b.owner_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.budgets b
+      WHERE b.id = budget_categories.budget_id
+        AND b.owner_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can update items in own budgets" ON public.budget_items;
+CREATE POLICY "Users can update items in own budgets"
+  ON public.budget_items FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.budget_categories bc
+      JOIN public.budgets b ON b.id = bc.budget_id
+      WHERE bc.id = budget_items.category_id
+        AND b.owner_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.budget_categories bc
+      JOIN public.budgets b ON b.id = bc.budget_id
+      WHERE bc.id = budget_items.category_id
+        AND b.owner_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can update media in own businesses" ON public.business_media;
+CREATE POLICY "Users can update media in own businesses"
+  ON public.business_media FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.businesses b
+      WHERE b.id = business_media.business_id
+        AND b.owner_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.businesses b
+      WHERE b.id = business_media.business_id
+        AND b.owner_id = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- Integrity fix: project owner must match assigned business owner
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.check_project_client_business()
+RETURNS TRIGGER AS $$
+DECLARE
+  business_owner_id uuid;
+BEGIN
+  IF NEW.business_id IS NOT NULL THEN
+    IF NEW.client_id IS NULL THEN
+      RAISE EXCEPTION 'Project must have a client when a business is assigned.';
+    END IF;
+
+    SELECT b.owner_id
+      INTO business_owner_id
+    FROM public.businesses b
+    WHERE b.id = NEW.business_id
+      AND b.client_id = NEW.client_id;
+
+    IF business_owner_id IS NULL THEN
+      RAISE EXCEPTION 'The selected business does not belong to the selected client.';
+    END IF;
+
+    IF NEW.owner_id IS DISTINCT FROM business_owner_id THEN
+      RAISE EXCEPTION 'Project owner must match the owner of the assigned business.';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ---------------------------------------------------------------------------
+-- PERF-001: Atomic reorder for tasks in one RPC
+-- task_data format: [{"id":"<task_uuid>","order_index":0,"status":"next"}, ...]
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.reorder_tasks_atomic(task_data jsonb)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  payload_count integer;
+  allowed_count integer;
+BEGIN
+  IF task_data IS NULL OR jsonb_typeof(task_data) <> 'array' THEN
+    RAISE EXCEPTION 'task_data must be a JSON array';
+  END IF;
+
+  payload_count := jsonb_array_length(task_data);
+  IF payload_count = 0 THEN
+    RETURN;
+  END IF;
+
+  WITH payload AS (
+    SELECT *
+    FROM jsonb_to_recordset(task_data) AS x(id uuid, order_index integer, status public.task_status)
+  )
+  SELECT COUNT(*)
+    INTO allowed_count
+  FROM payload p
+  JOIN public.tasks t ON t.id = p.id
+  JOIN public.projects pr ON pr.id = t.project_id
+  WHERE pr.owner_id = auth.uid();
+
+  IF allowed_count <> payload_count THEN
+    RAISE EXCEPTION 'One or more tasks are missing or not owned by the authenticated user';
+  END IF;
+
+  UPDATE public.tasks t
+  SET order_index = p.order_index,
+      status = COALESCE(p.status, t.status),
+      updated_at = NOW()
+  FROM (
+    SELECT *
+    FROM jsonb_to_recordset(task_data) AS x(id uuid, order_index integer, status public.task_status)
+  ) p
+  WHERE t.id = p.id;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- PERF-003: Atomic duplicate of budget, categories and items in one RPC
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.duplicate_budget_atomic(source_id uuid, new_name text)
+RETURNS uuid
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  source_budget public.budgets%ROWTYPE;
+  source_category record;
+  new_budget_id uuid;
+  new_category_id uuid;
+BEGIN
+  IF source_id IS NULL THEN
+    RAISE EXCEPTION 'source_id is required';
+  END IF;
+
+  SELECT *
+    INTO source_budget
+  FROM public.budgets b
+  WHERE b.id = source_id
+    AND b.owner_id = auth.uid();
+
+  IF source_budget.id IS NULL THEN
+    RAISE EXCEPTION 'Source budget not found or not owned by authenticated user';
+  END IF;
+
+  INSERT INTO public.budgets (name, description, project_id, owner_id)
+  VALUES (
+    COALESCE(NULLIF(BTRIM(new_name), ''), source_budget.name || ' (Copy)'),
+    source_budget.description,
+    source_budget.project_id,
+    source_budget.owner_id
+  )
+  RETURNING id INTO new_budget_id;
+
+  FOR source_category IN
+    SELECT bc.*
+    FROM public.budget_categories bc
+    WHERE bc.budget_id = source_id
+    ORDER BY COALESCE(bc.sort_order, 0), bc.id
+  LOOP
+    INSERT INTO public.budget_categories (budget_id, name, description, sort_order)
+    VALUES (
+      new_budget_id,
+      source_category.name,
+      source_category.description,
+      COALESCE(source_category.sort_order, 0)
+    )
+    RETURNING id INTO new_category_id;
+
+    INSERT INTO public.budget_items (
+      category_id,
+      name,
+      description,
+      quantity,
+      unit_price,
+      link,
+      status,
+      is_recurrent,
+      notes,
+      sort_order
+    )
+    SELECT
+      new_category_id,
+      bi.name,
+      bi.description,
+      bi.quantity,
+      bi.unit_price,
+      bi.link,
+      bi.status,
+      bi.is_recurrent,
+      bi.notes,
+      COALESCE(bi.sort_order, 0)
+    FROM public.budget_items bi
+    WHERE bi.category_id = source_category.id
+    ORDER BY COALESCE(bi.sort_order, 0), bi.id;
+  END LOOP;
+
+  RETURN new_budget_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.reorder_tasks_atomic(jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.duplicate_budget_atomic(uuid, text) TO authenticated;


### PR DESCRIPTION
### Motivation
- Mejorar consistencia y rendimiento moviendo reordenados y duplicados complejos al servidor mediante RPCs atómicos.
- Eliminar patrones de actualización secuencial con `for await` que podían causar condiciones de carrera y múltiples escrituras.
- Evitar N+1 en la generación de resúmenes de TODOs para reducir llamadas a la base de datos.

### Description
- Reemplazada la duplicación manual en `app/budgets/actions.ts` por una única llamada RPC a `duplicate_budget_atomic` y eliminadas las inserciones/loops cliente-side; se eliminaron los `as any` en las llamadas afectadas y se añadieron casts/`as never` donde fue necesario para ajustar los tipos del cliente Supabase.
- Refactorizado `updateTaskOrder` en `app/actions/tasks.ts` para calcular los índices en memoria, construir un `reorderPayload` y persistir todo en una sola llamada RPC `reorder_tasks_atomic`, además de tipar correctamente las estructuras usadas (`TaskWithProject`, `TaskUpdate`).
- Corregido el N+1 en `getProjectsWithTodoSummaryAction` en `app/todo/actions.ts` realizando un único fetch `getTodoItemsByListIds(allListIds)` y agrupando los items por `list_id` en memoria antes de construir los resúmenes por proyecto.
- Ajustes menores de tipado en `createBudget`, `updateBudget`, `createTask`, `updateTask` y otros puntos para eliminar `as any` inseguros y mejorar la compatibilidad con `lib/supabase/types`.

### Testing
- Ejecutado `npm run typecheck` y pasó sin errores después de los cambios de tipos.
- Intentado `npm run lint -- --file app/actions/tasks.ts --file app/budgets/actions.ts --file app/todo/actions.ts`, que falló en este entorno por la resolución del plugin local `eslint-plugin-clear-queue` (no relacionado con los cambios de lógica).
- Verificado que los ficheros modificados están registrados en el commit (`git commit` realizado con mensaje descriptivo) y que los cambios compilan localmente según `tsc`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ed4fa7208331b9bd797f85767c80)